### PR TITLE
feat: expose close() on connection multiplexer singleton

### DIFF
--- a/redis-com-client/CacheFactory.cs
+++ b/redis-com-client/CacheFactory.cs
@@ -27,5 +27,10 @@ namespace redis_com_client
 
             return _redisClientsManager.GetServer("localhost", 6379);
         }
+
+        public static void Close(bool allowCommandsToComplete = true)
+        {
+            _redisClientsManager.Close(allowCommandsToComplete);
+        }
     }
 }

--- a/redis-com-client/CacheManager.cs
+++ b/redis-com-client/CacheManager.cs
@@ -22,6 +22,11 @@ namespace redis_com_client
             _redisinstance = CacheFactory.GetInstance(configuration:configuration);
         }
 
+        public void Close(bool allowCommandsToComplete = true)
+        {
+            CacheFactory.Close(allowCommandsToComplete);
+        }
+
         public void Del(string key)
         {
             _redisinstance.KeyDelete(key);


### PR DESCRIPTION
> By default recent versions of Redis don't close the connection with the client if the client is idle for many seconds: the connection will remain open forever.

https://redis.io/docs/reference/clients/#client-timeouts

Normally, when redis-com-client is disposed - it should close the connection.  However, it seems there are circumstances which prevent the COM object from being disposed properly.  This is leaving connections open indefinitely on the server side.

To remedy this, redis-com-client should expose the `close()` function from ConnectionMultiplexer.